### PR TITLE
Carrier and group restriction don't work

### DIFF
--- a/classes/CustomPaymentMethod.php
+++ b/classes/CustomPaymentMethod.php
@@ -137,7 +137,7 @@ class CustomPaymentMethod extends ObjectModel
         $groups = array_map('intval', $groups);
 
         $sql = new DbQuery();
-        $sql->select('cpm.*, cpml.`id_lang`, cpms.`id_shop`');
+        $sql->select('DISTINCT cpm.*, cpml.`id_lang`, cpms.`id_shop`');
         if (Group::isFeatureActive()) {
             $sql->select('cpmg.`id_group`');
         }
@@ -163,22 +163,20 @@ class CustomPaymentMethod extends ObjectModel
             $sql->innerJoin(
                 'custom_payment_method_carrier',
                 'cpmc',
-                'cpmc.`id_carrier` = '.(int) $idCarrier
+                'cpmc.`id_custom_payment_method` = cpm.`id_custom_payment_method` AND cpmc.`id_carrier` = '.(int) $idCarrier
             );
         }
         if (!empty($groups) && Group::isFeatureActive()) {
             $sql->innerJoin(
                 'custom_payment_method_group',
                 'cpmg',
-                'cpmg.`id_group` IN ('.implode($groups, ',').')'
+                'cpmc.`id_custom_payment_method` = cpm.`id_custom_payment_method` AND cpmg.`id_group` IN ('.implode($groups, ',').')'
             );
         }
         if ($active) {
             $sql->where('`active` = 1');
         }
-        $sql->groupBy('cpm.`'.bqSQL(static::$definition['primary']).'`');
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
-
         return $result;
     }
 


### PR DESCRIPTION
This pull request closes issue #3

There are two changes:

1. added custom payment primary key to joins to ```custom_payment_method_carrier``` and ```custom_payment_method_group``` tables. This fixes the bug

2. I replaced *group by* with *distinct*. The group by expression was not 100% correct and it fails under strict sql mode: only_full_group_by. This is not a problem for thirtybees because it uses forgiving sql mode, but it should be fixed anyway
> ERROR 1055 (42000): Expression #11 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'thirtybees.cpml.name' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by



