### PR TITLE
Update years and use HTTPS for links (where needed) in license headers.

### DIFF
--- a/classes/CustomPaymentMethod.php
+++ b/classes/CustomPaymentMethod.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.md
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
@@ -15,13 +15,13 @@
  * @author    0RS <admin@prestalab.ru>
  * @author    thirty bees <modules@thirtybees.com>
  * @copyright 2009-2017 PrestaLab.Ru
- * @copyright 2017-2021 thirty bees
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *
  * This module is based on the original `universalpay` module
  * which you can find on https://github.com/universalpay/universalpay
  *
- * Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version
+ * Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version
  */
 
 namespace CustomPaymentsModule;

--- a/classes/index.php
+++ b/classes/index.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.md
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
@@ -15,13 +15,13 @@
  * @author    0RS <admin@prestalab.ru>
  * @author    thirty bees <modules@thirtybees.com>
  * @copyright 2009-2017 PrestaLab.Ru
- * @copyright 2017-2021 thirty bees
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *
  * This module is based on the original `universalpay` module
  * which you can find on https://github.com/universalpay/universalpay
  *
- * Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version
+ * Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version
  */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');

--- a/controllers/admin/AdminCustomPayments.php
+++ b/controllers/admin/AdminCustomPayments.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.md
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
@@ -15,13 +15,13 @@
  * @author    0RS <admin@prestalab.ru>
  * @author    thirty bees <modules@thirtybees.com>
  * @copyright 2009-2017 PrestaLab.Ru
- * @copyright 2017-2021 thirty bees
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *
  * This module is based on the original `universalpay` module
  * which you can find on https://github.com/universalpay/universalpay
  *
- * Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version
+ * Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version
  */
 
 use CustomPaymentsModule\CustomPaymentMethod;

--- a/controllers/admin/index.php
+++ b/controllers/admin/index.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.md
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
@@ -15,13 +15,13 @@
  * @author    0RS <admin@prestalab.ru>
  * @author    thirty bees <modules@thirtybees.com>
  * @copyright 2009-2017 PrestaLab.Ru
- * @copyright 2017-2021 thirty bees
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *
  * This module is based on the original `universalpay` module
  * which you can find on https://github.com/universalpay/universalpay
  *
- * Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version
+ * Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version
  */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');

--- a/controllers/front/index.php
+++ b/controllers/front/index.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.md
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
@@ -15,13 +15,13 @@
  * @author    0RS <admin@prestalab.ru>
  * @author    thirty bees <modules@thirtybees.com>
  * @copyright 2009-2017 PrestaLab.Ru
- * @copyright 2017-2021 thirty bees
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *
  * This module is based on the original `universalpay` module
  * which you can find on https://github.com/universalpay/universalpay
  *
- * Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version
+ * Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version
  */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');

--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.md
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
@@ -15,13 +15,13 @@
  * @author    0RS <admin@prestalab.ru>
  * @author    thirty bees <modules@thirtybees.com>
  * @copyright 2009-2017 PrestaLab.Ru
- * @copyright 2017-2021 thirty bees
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *
  * This module is based on the original `universalpay` module
  * which you can find on https://github.com/universalpay/universalpay
  *
- * Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version
+ * Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version
  */
 
 use CustomPaymentsModule\CustomPaymentMethod;

--- a/controllers/front/validation.php
+++ b/controllers/front/validation.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.md
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
@@ -15,13 +15,13 @@
  * @author    0RS <admin@prestalab.ru>
  * @author    thirty bees <modules@thirtybees.com>
  * @copyright 2009-2017 PrestaLab.Ru
- * @copyright 2017-2021 thirty bees
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *
  * This module is based on the original `universalpay` module
  * which you can find on https://github.com/universalpay/universalpay
  *
- * Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version
+ * Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version
  */
 
 use CustomPaymentsModule\CustomPaymentMethod;

--- a/controllers/index.php
+++ b/controllers/index.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.md
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
@@ -15,13 +15,13 @@
  * @author    0RS <admin@prestalab.ru>
  * @author    thirty bees <modules@thirtybees.com>
  * @copyright 2009-2017 PrestaLab.Ru
- * @copyright 2017-2021 thirty bees
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *
  * This module is based on the original `universalpay` module
  * which you can find on https://github.com/universalpay/universalpay
  *
- * Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version
+ * Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version
  */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');

--- a/custompayments.php
+++ b/custompayments.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.md
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
@@ -15,13 +15,13 @@
  * @author    0RS <admin@prestalab.ru>
  * @author    thirty bees <modules@thirtybees.com>
  * @copyright 2009-2017 PrestaLab.Ru
- * @copyright 2017-2021 thirty bees
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *
  * This module is based on the original `universalpay` module
  * which you can find on https://github.com/universalpay/universalpay
  *
- * Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version
+ * Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version
  */
 
 use CustomPaymentsModule\CustomPaymentMethod;

--- a/index.php
+++ b/index.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.md
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
@@ -15,13 +15,13 @@
  * @author    0RS <admin@prestalab.ru>
  * @author    thirty bees <modules@thirtybees.com>
  * @copyright 2009-2017 PrestaLab.Ru
- * @copyright 2017-2021 thirty bees
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *
  * This module is based on the original `universalpay` module
  * which you can find on https://github.com/universalpay/universalpay
  *
- * Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version
+ * Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version
  */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');

--- a/translations/index.php
+++ b/translations/index.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.md
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
@@ -15,13 +15,13 @@
  * @author    0RS <admin@prestalab.ru>
  * @author    thirty bees <modules@thirtybees.com>
  * @copyright 2009-2017 PrestaLab.Ru
- * @copyright 2017-2021 thirty bees
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *
  * This module is based on the original `universalpay` module
  * which you can find on https://github.com/universalpay/universalpay
  *
- * Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version
+ * Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version
  */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');

--- a/upgrade/index.php
+++ b/upgrade/index.php
@@ -1,20 +1,20 @@
 <?php
 /**
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
  *
  *  @author    thirty bees <modules@thirtybees.com>
- *  @copyright 2017-2021 thirty bees
- *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  @copyright 2017-2024 thirty bees
+ *  @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *  PrestaShop is an internationally registered trademark & property of PrestaShop SA
  */
 

--- a/upgrade/upgrade-1.1.0.php
+++ b/upgrade/upgrade-1.1.0.php
@@ -7,14 +7,14 @@
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
  *
  *  @author    thirty bees <modules@thirtybees.com>
- *  @copyright 2017-2021 thirty bees
- *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  @copyright 2017-2024 thirty bees
+ *  @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
 
 if (!defined('_TB_VERSION_')) {

--- a/views/index.php
+++ b/views/index.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.md
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
@@ -15,13 +15,13 @@
  * @author    0RS <admin@prestalab.ru>
  * @author    thirty bees <modules@thirtybees.com>
  * @copyright 2009-2017 PrestaLab.Ru
- * @copyright 2017-2021 thirty bees
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *
  * This module is based on the original `universalpay` module
  * which you can find on https://github.com/universalpay/universalpay
  *
- * Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version
+ * Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version
  */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');

--- a/views/templates/admin/configure.tpl
+++ b/views/templates/admin/configure.tpl
@@ -1,12 +1,12 @@
 {*
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.md
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
@@ -14,13 +14,13 @@
  * @author    0RS <admin@prestalab.ru>
  * @author    thirty bees <modules@thirtybees.com>
  * @copyright 2009-2017 PrestaLab.Ru
- * @copyright 2017-2021 thirty bees
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *
  * This module is based on the original `universalpay` module
  * which you can find on https://github.com/universalpay/universalpay
  *
- * Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version
+ * Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version
 *}
 <div class="panel">
     <h3><i class="icon icon-puzzle-piece"></i> {l s='Custom payments' mod='custompayments'}</h3>
@@ -38,5 +38,5 @@
             <a href="https://docs.thirtybees.com/native-modules/custompayments/" target="_blank">https://docs.thirtybees.com/native-modules/custompayments/</a>
         </li>
     </ol>
-    <em>{l s='This module is based on the original `universalpay` module which you can find on %s. Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version' mod='custompayments' sprintf=['https://github.com/universalpay/universalpay']}</em>
+    <em>{l s='This module is based on the original `universalpay` module which you can find on %s. Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version' mod='custompayments' sprintf=['https://github.com/universalpay/universalpay']}</em>
 </div>

--- a/views/templates/admin/index.php
+++ b/views/templates/admin/index.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.md
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
@@ -15,13 +15,13 @@
  * @author    0RS <admin@prestalab.ru>
  * @author    thirty bees <modules@thirtybees.com>
  * @copyright 2009-2017 PrestaLab.Ru
- * @copyright 2017-2021 thirty bees
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *
  * This module is based on the original `universalpay` module
  * which you can find on https://github.com/universalpay/universalpay
  *
- * Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version
+ * Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version
  */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');

--- a/views/templates/front/index.php
+++ b/views/templates/front/index.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.md
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
@@ -15,13 +15,13 @@
  * @author    0RS <admin@prestalab.ru>
  * @author    thirty bees <modules@thirtybees.com>
  * @copyright 2009-2017 PrestaLab.Ru
- * @copyright 2017-2021 thirty bees
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *
  * This module is based on the original `universalpay` module
  * which you can find on https://github.com/universalpay/universalpay
  *
- * Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version
+ * Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version
  */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');

--- a/views/templates/front/payment_execution.tpl
+++ b/views/templates/front/payment_execution.tpl
@@ -1,13 +1,13 @@
 {*
  *
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.md
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
@@ -15,13 +15,13 @@
  * @author    0RS <admin@prestalab.ru>
  * @author    thirty bees <modules@thirtybees.com>
  * @copyright 2009-2017 PrestaLab.Ru
- * @copyright 2017-2021 thirty bees
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *
  * This module is based on the original `universalpay` module
  * which you can find on https://github.com/universalpay/universalpay
  *
- * Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version
+ * Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version
  *
 *}
 

--- a/views/templates/hook/index.php
+++ b/views/templates/hook/index.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.md
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
@@ -15,13 +15,13 @@
  * @author    0RS <admin@prestalab.ru>
  * @author    thirty bees <modules@thirtybees.com>
  * @copyright 2009-2017 PrestaLab.Ru
- * @copyright 2017-2021 thirty bees
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *
  * This module is based on the original `universalpay` module
  * which you can find on https://github.com/universalpay/universalpay
  *
- * Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version
+ * Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version
  */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');

--- a/views/templates/hook/payment.tpl
+++ b/views/templates/hook/payment.tpl
@@ -1,13 +1,13 @@
 {*
  *
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.md
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
@@ -15,13 +15,13 @@
  * @author    0RS <admin@prestalab.ru>
  * @author    thirty bees <modules@thirtybees.com>
  * @copyright 2009-2017 PrestaLab.Ru
- * @copyright 2017-2021 thirty bees
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *
  * This module is based on the original `universalpay` module
  * which you can find on https://github.com/universalpay/universalpay
  *
- * Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version
+ * Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version
  *
 *}
 

--- a/views/templates/index.php
+++ b/views/templates/index.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Copyright (C) 2017-2021 thirty bees
+ * Copyright (C) 2017-2024 thirty bees
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Academic Free License (AFL 3.0)
  * that is bundled with this package in the file LICENSE.md
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/afl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@thirtybees.com so we can send you a copy immediately.
@@ -15,13 +15,13 @@
  * @author    0RS <admin@prestalab.ru>
  * @author    thirty bees <modules@thirtybees.com>
  * @copyright 2009-2017 PrestaLab.Ru
- * @copyright 2017-2021 thirty bees
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *
  * This module is based on the original `universalpay` module
  * which you can find on https://github.com/universalpay/universalpay
  *
- * Credits go to PrestaLab.Ru (http://www.prestalab.ru) for making the initial version
+ * Credits go to PrestaLab.Ru (https://www.prestalab.ru) for making the initial version
  */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');


### PR DESCRIPTION
Update years and use HTTPS for links (where needed) in license headers.